### PR TITLE
主要是打包相关的一些修改

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/*/target/
+target
 /build/

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.stuxuhai</groupId>
+		<artifactId>hdata</artifactId>
+		<version>0.2.8</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<artifactId>assembly</artifactId>
+	<name>hdata-assembly</name>
+	<properties>
+		<topdir>${project.basedir}/..</topdir>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>make-package</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${topdir}/build</outputDirectory>
+							<finalName>hdata-${project.version}</finalName>
+							<appendAssemblyId>false</appendAssemblyId>
+							<descriptors>
+								<descriptor>src/build/package.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/assembly/src/build/package.xml
+++ b/assembly/src/build/package.xml
@@ -1,0 +1,78 @@
+<assembly
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+	<id>package</id>
+	<formats>
+		<format>tar.gz</format>
+	</formats>
+	<fileSets>
+		<!-- bin -->
+		<fileSet>
+			<directory>${topdir}/bin</directory>
+			<outputDirectory>bin</outputDirectory>
+			<includes>
+				<include>hdata</include>
+			</includes>
+		</fileSet>
+		<!-- conf -->
+		<fileSet>
+			<directory>${topdir}/conf</directory>
+			<outputDirectory>conf</outputDirectory>
+		</fileSet>
+		<!-- lib -->
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-api</directory>
+			<outputDirectory>lib</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-core</directory>
+			<outputDirectory>lib</outputDirectory>
+		</fileSet>
+		<!-- plugins -->
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-console</directory>
+			<outputDirectory>plugins/console</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-csv</directory>
+			<outputDirectory>plugins/csv</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-excel</directory>
+			<outputDirectory>plugins/excel</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-ftp</directory>
+			<outputDirectory>plugins/ftp</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-hbase</directory>
+			<outputDirectory>plugins/hbase</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-hdfs</directory>
+			<outputDirectory>plugins/hdfs</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-hive</directory>
+			<outputDirectory>plugins/hive</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-http</directory>
+			<outputDirectory>plugins/http</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-jdbc</directory>
+			<outputDirectory>plugins/jdbc</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-kafka</directory>
+			<outputDirectory>plugins/kafka</outputDirectory>
+		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-mongodb</directory>
+			<outputDirectory>plugins/mongodb</outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/bin/hdata
+++ b/bin/hdata
@@ -30,7 +30,12 @@ if [ ! -x "$JAVA" ]; then
     exit 1
 fi
 
-HDATA_CLASSPATH='.'
+if [ -z "$HDATA_CLASSPATH" ]; then
+    HDATA_CLASSPATH='.'
+else
+    HDATA_CLASSPATH=".:$HDATA_CLASSPATH"
+fi
+
 for f in $HDATA_LIB_DIR/*.jar; do
     HDATA_CLASSPATH=${HDATA_CLASSPATH}:$f;
 done

--- a/hdata-console/pom.xml
+++ b/hdata-console/pom.xml
@@ -12,6 +12,7 @@
 		<dependency>
 			<groupId>com.github.stuxuhai</groupId>
 			<artifactId>hdata-api</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/hdata-hbase/pom.xml
+++ b/hdata-hbase/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.github.stuxuhai</groupId>
@@ -9,8 +9,6 @@
 	<artifactId>hdata-hbase</artifactId>
 
 	<properties>
-		<hadoop.version>2.7.1</hadoop.version>
-		<hbase.version>1.1.2</hbase.version>
 	</properties>
 
 	<dependencies>
@@ -23,26 +21,31 @@
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
 			<version>${hadoop.version}</version>
+			<scope>${hadoop.scope}</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-hdfs</artifactId>
 			<version>${hadoop.version}</version>
+			<scope>${hadoop.scope}</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-mapreduce-client-core</artifactId>
 			<version>${hadoop.version}</version>
+			<scope>${hadoop.scope}</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-client</artifactId>
 			<version>${hbase.version}</version>
+			<scope>${hbase.scope}</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.zookeeper</groupId>
 			<artifactId>zookeeper</artifactId>
-			<version>3.4.6</version>
+			<version>${zookeeper.version}</version>
+			<scope>${zookeeper.scope}</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/hdata-hdfs/pom.xml
+++ b/hdata-hdfs/pom.xml
@@ -9,7 +9,6 @@
 	<artifactId>hdata-hdfs</artifactId>
 
 	<properties>
-		<hadoop.version>2.7.1</hadoop.version>
 	</properties>
 
 	<dependencies>
@@ -22,11 +21,13 @@
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
 			<version>${hadoop.version}</version>
+			<scope>${hadoop.scope}</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-hdfs</artifactId>
 			<version>${hadoop.version}</version>
+			<scope>${hadoop.scope}</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.anarres.lzo</groupId>

--- a/hdata-hive/pom.xml
+++ b/hdata-hive/pom.xml
@@ -9,8 +9,6 @@
 	<artifactId>hdata-hive</artifactId>
 
 	<properties>
-		<hive.version>1.2.1</hive.version>
-		<hadoop.version>2.6.0</hadoop.version>
 	</properties>
 
 	<dependencies>
@@ -34,6 +32,7 @@
 			<groupId>org.apache.hive.hcatalog</groupId>
 			<artifactId>hive-hcatalog-core</artifactId>
 			<version>${hive.version}</version>
+			<scope>${hive.scope}</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
@@ -45,6 +44,7 @@
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-mapreduce-client-core</artifactId>
 			<version>${hadoop.version}</version>
+			<scope>${hadoop.scope}</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
@@ -56,6 +56,7 @@
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
 			<version>${hadoop.version}</version>
+			<scope>${hadoop.scope}</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
@@ -67,6 +68,7 @@
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-hdfs</artifactId>
 			<version>${hadoop.version}</version>
+			<scope>${hadoop.scope}</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,42 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>make-package</id>
+			<properties>
+				<modulesOutputDirectory>${basedir}/../target/all-modules/${project.artifactId}</modulesOutputDirectory>
+			</properties>
+			<modules>
+				<module>assembly</module>
+			</modules>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-jar-plugin</artifactId>
+						<configuration>
+							<outputDirectory>${modulesOutputDirectory}</outputDirectory>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>copy-dependencies</goal>
+								</goals>
+								<configuration>
+									<outputDirectory>${modulesOutputDirectory}</outputDirectory>
+									<includeScope>runtime</includeScope>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 	<build>
@@ -102,6 +138,11 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>
 					<version>2.10</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<version>2.5.3</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,14 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
+		<zookeeper.version>3.4.6</zookeeper.version>
+		<hadoop.version>2.7.1</hadoop.version>
+		<hbase.version>1.1.2</hbase.version>
+		<hive.version>1.2.1</hive.version>
+		<zookeeper.scope>compile</zookeeper.scope>
+		<hadoop.scope>compile</hadoop.scope>
+		<hbase.scope>compile</hbase.scope>
+		<hive.scope>compile</hive.scope>
 	</properties>
 
 	<dependencyManagement>
@@ -29,6 +37,30 @@
 	</dependencyManagement>
 
 	<profiles>
+		<profile>
+			<id>cdh5</id>
+			<properties>
+				<cdh.version>cdh5.7.4</cdh.version>
+				<zookeeper.version>3.4.5-${cdh.version}</zookeeper.version>
+				<hadoop.version>2.6.0-${cdh.version}</hadoop.version>
+				<hbase.version>1.2.0-${cdh.version}</hbase.version>
+				<hive.version>1.1.0-${cdh.version}</hive.version>
+				<zookeeper.scope>provided</zookeeper.scope>
+				<hadoop.scope>provided</hadoop.scope>
+				<hbase.scope>provided</hbase.scope>
+				<hive.scope>provided</hive.scope>
+			</properties>
+			<repositories>
+				<repository>
+					<id>cdh.repo</id>
+					<url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
+					<name>Cloudera Repositories</name>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</repository>
+			</repositories>
+		</profile>
 		<profile>
 			<id>copy-dependency</id>
 			<build>


### PR DESCRIPTION
#### 修改如下:

+ 新增了 `make-package` 配置, 使用 maven 提供的插件来打包, 不需要借助外部脚本啦, 因此 **不再需要 package-hdata.* 以及  zip.exe** 啦
+ `console` 模块里的 `hdata-api` 的 scope 可以设置成 `provided`, 之前修改的时候漏掉了
+ 新增了 cdh5 的打包方式, 当然主要是为了:
    +  统一 hadoop/hbase/hive 之类的版本, 配置放到 pom.xml, 这样大家可以打自己的包而不用去修改 pom.xml 
    + 允许配置这些包的 `scope`, 可以选择性的减少最终的打包
+ `bin/hdata` 脚本尊重外部已经设置了的 `HDATA_CLASSPATH`, 辅助上面忽略一些庞大的包的情况

#### 示例: 

+ 打包

```sh
# 只需要 mvn 就可以打包
mvn clean package -Pmake-package

# 还可以夹带自己的配置, 是不是很方便
mvn clean package -Pcdh5 -Pmake-package
```

+ 夹带自己的 classpath

```sh
export HDATA_CLASSPATH="$(hadoop classpath)" && ./hdata  --reader hdfs ........
```

PS: package-hdata.* 以及  zip.exe 目前没有, 只是想做到最小修改, 删不删还要看作者大大的意思
PPS: 还请多多 review, 不知道有没有引入新坑
PPPS: 如果支持 spi 的方式使用自定义插件那就更好啦, (此处当然还是建议大家都把自己的插件共享出来)