### PR TITLE
缺省从 HiveConf 中读取 metastore.uris

### DIFF
--- a/hdata-hive/src/main/java/com/github/stuxuhai/hdata/plugin/reader/hive/HiveSplitter.java
+++ b/hdata-hive/src/main/java/com/github/stuxuhai/hdata/plugin/reader/hive/HiveSplitter.java
@@ -39,9 +39,13 @@ public class HiveSplitter extends Splitter {
 
 	@Override
 	public List<PluginConfig> split(JobConfig jobConfig) {
-		List<PluginConfig> list = new ArrayList<PluginConfig>();
+		List<PluginConfig> list = new ArrayList<>();
 		PluginConfig readerConfig = jobConfig.getReaderConfig();
 		String metastoreUris = readerConfig.getString(HiveReaderProperties.METASTORE_URIS);
+		if (metastoreUris == null || metastoreUris.isEmpty()) {
+			HiveConf hiveConf = new HiveConf();
+			metastoreUris = hiveConf.getVar(ConfVars.METASTOREURIS);
+		}
 		Preconditions.checkNotNull(metastoreUris, "Hive reader required property: metastore.uris");
 
 		String hadoopUser = readerConfig.getString(HiveReaderProperties.HADOOP_USER);


### PR DESCRIPTION
+ 使用 HiveConf 中的 `hive.metastore.uris` 作为 `metastore.uris` 的默认值(没有指定时)
只要将 `hive-site.xml` 添加到 classpath 就可以读到这个值了,

因此, `metastore.uris` 不再是必填的了
**合并之后还请更新一下 README.md**