### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ keyword.escaper|否|关键字转义字符，默认为\`|
 
 参数        | 是否必选   | 描述                    |
 -----------| ----- | ---------------------------------------- |
+metastore.uris|否|Hive Metastore连接地址，如：thrift://localhost:9083, 默认: HiveConf.getVar(ConfVars.METASTOREURIS) 即 `hive-site.xml` 中的 `hive.metastore.uris` |
 database|否|数据库名，默认：default|
 table|是|表名|
 partitions|否|分区，例如: visit_date='2016-07-07'|
@@ -250,6 +251,7 @@ keyword.escaper|否|关键字转义字符，默认为\`|
 
 参数        | 是否必选   | 描述                    |
 -----------| ----- | ---------------------------------------- |
+metastore.uris|否|Hive Metastore连接地址，如：thrift://localhost:9083, 默认: HiveConf.getVar(ConfVars.METASTOREURIS) 即 `hive-site.xml` 中的 `hive.metastore.uris` |
 database|否|数据库名，默认：default|
 table|是|表名|
 partitions|否|分区条件，如：day='20140418'|


### PR DESCRIPTION
:last_quarter_moon:  
@stuxuhai 可能是理解错了, 这个参数没有去掉, 只是提供了默认值, 优先使用提供的值, 如果没有指定这个参数,会尝试从 HiveConf 中获取, 如果 classpath 没有配置文件 是找不到的, 那时候还是需要提供
后续我会补充一个 wiki 告诉大家如何根据自己已有的 hive 打包, 并如何使用不内置 hive/hadoop/hbase 的轻打包, 以及如何添加外置的包等等