### PR TITLE
[plugin] 自用的一个 wit 插件

### DIFF
--- a/assembly/src/build/package.xml
+++ b/assembly/src/build/package.xml
@@ -71,5 +71,9 @@
 			<directory>${topdir}/target/all-modules/hdata-mongodb</directory>
 			<outputDirectory>plugins/mongodb</outputDirectory>
 		</fileSet>
+		<fileSet>
+			<directory>${topdir}/target/all-modules/hdata-wit</directory>
+			<outputDirectory>plugins/wit</outputDirectory>
+		</fileSet>
 	</fileSets>
 </assembly>

--- a/conf/plugins.xml
+++ b/conf/plugins.xml
@@ -89,5 +89,9 @@
 			<name>excel</name>
 			<class>com.github.stuxuhai.hdata.plugin.excel.writer.ExcelWriter</class>
 		</writer>
+		<writer>
+			<name>wit</name>
+			<class>com.github.stuxuhai.hdata.plugin.wit.writer.WitWriter</class>
+		</writer>
 	</writers>
 </plugins>

--- a/hdata-wit/pom.xml
+++ b/hdata-wit/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.stuxuhai</groupId>
+		<artifactId>hdata</artifactId>
+		<version>0.2.8</version>
+	</parent>
+	<artifactId>hdata-wit</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.github.stuxuhai</groupId>
+			<artifactId>hdata-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.stuxuhai</groupId>
+			<artifactId>hdata-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${slf4j.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.febit.wit</groupId>
+			<artifactId>wit-core</artifactId>
+			<version>2.3.0-beta</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/Methods.java
+++ b/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/Methods.java
@@ -1,0 +1,30 @@
+package com.github.stuxuhai.hdata.plugin.wit;
+
+import com.github.stuxuhai.hdata.api.Record;
+import org.febit.wit.Engine;
+import org.febit.wit.core.NativeFactory;
+import org.febit.wit.global.GlobalManager;
+import org.febit.wit.util.JavaNativeUtil;
+
+/**
+ *
+ * @author zqq90
+ */
+public class Methods implements WitEnginePlugin {
+
+    public static final Record newRecord() {
+        return new WitDynamicRecord();
+    }
+
+    public static final Record copyRecord(Record record) {
+        return new WitDynamicRecord(record);
+    }
+
+    @Override
+    public void handle(Engine engine) {
+        NativeFactory nativeFactory = engine.getNativeFactory();
+        GlobalManager manager = engine.getGlobalManager();
+        JavaNativeUtil.addStaticMethods(manager, nativeFactory, Methods.class);
+        JavaNativeUtil.addConstFields(manager, nativeFactory, Methods.class);
+    }
+}

--- a/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/WitDynamicRecord.java
+++ b/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/WitDynamicRecord.java
@@ -8,12 +8,20 @@ import java.util.List;
  *
  * @author zqq90
  */
-public class WitRecord implements Record {
+public class WitDynamicRecord implements Record {
 
     private final List<Object> datas;
 
-    public WitRecord() {
+    public WitDynamicRecord() {
         this.datas = new ArrayList<>();
+    }
+
+    public WitDynamicRecord(Record record) {
+        List<Object> list = new ArrayList<>();
+        for (int i = 0, len = record.size(); i < len; i++) {
+            list.add(record.get(i));
+        }
+        this.datas = list;
     }
 
     @Override
@@ -37,7 +45,6 @@ public class WitRecord implements Record {
     @Override
     public Object get(int index) {
         if (index >= this.datas.size()) {
-            // XXX: should throw IndexOutOfBoundsException ?
             return null;
         }
         return this.datas.get(index);

--- a/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/WitEnginePlugin.java
+++ b/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/WitEnginePlugin.java
@@ -1,0 +1,12 @@
+package com.github.stuxuhai.hdata.plugin.wit;
+
+import org.febit.wit.Engine;
+
+/**
+ *
+ * @author zqq90
+ */
+public interface WitEnginePlugin {
+
+    void handle(Engine engine);
+}

--- a/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/WitRecord.java
+++ b/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/WitRecord.java
@@ -1,0 +1,51 @@
+package com.github.stuxuhai.hdata.plugin.wit;
+
+import com.github.stuxuhai.hdata.api.Record;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * @author zqq90
+ */
+public class WitRecord implements Record {
+
+    private final List<Object> datas;
+
+    public WitRecord() {
+        this.datas = new ArrayList<>();
+    }
+
+    @Override
+    public void add(Object object) {
+        this.datas.add(object);
+    }
+
+    @Override
+    public void add(int index, Object object) {
+        final int size = this.datas.size();
+        if (index >= size) {
+            for (int i = index - size; i != 0; i--) {
+                this.datas.add(null);
+            }
+            this.datas.add(object);
+        } else {
+            this.datas.set(index, object);
+        }
+    }
+
+    @Override
+    public Object get(int index) {
+        if (index >= this.datas.size()) {
+            // XXX: should throw IndexOutOfBoundsException ?
+            return null;
+        }
+        return this.datas.get(index);
+    }
+
+    @Override
+    public int size() {
+        return this.datas.size();
+    }
+
+}

--- a/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/resolvers/RecordResolver.java
+++ b/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/resolvers/RecordResolver.java
@@ -1,0 +1,45 @@
+package com.github.stuxuhai.hdata.plugin.wit.resolvers;
+
+import com.github.stuxuhai.hdata.api.Record;
+import org.febit.wit.exceptions.ScriptRuntimeException;
+import org.febit.wit.resolvers.GetResolver;
+import org.febit.wit.resolvers.SetResolver;
+import org.febit.wit.util.StringUtil;
+
+/**
+ *
+ * @author zqq90
+ */
+public class RecordResolver implements GetResolver, SetResolver {
+
+    @Override
+    public Class getMatchClass() {
+        return Record.class;
+    }
+
+    @Override
+    public Object get(Object object, Object property) {
+        if (property instanceof Number) {
+            try {
+                return ((Record) object).get(((Number) property).intValue());
+            } catch (IndexOutOfBoundsException e) {
+                throw new ScriptRuntimeException(StringUtil.format("index out of bounds:{}", property));
+            }
+        }
+        switch (property.toString()) {
+            case "size":
+            case "length":
+                return ((Record) object).size();
+        }
+        throw new ScriptRuntimeException(StringUtil.format("Invalid property or can't read: com.github.stuxuhai.hdata.api.Record#{}", property));
+    }
+
+    @Override
+    public void set(Object object, Object property, Object value) {
+        if (property instanceof Number) {
+            ((Record) object).add(((Number) property).intValue(), value);
+            return;
+        }
+        throw new ScriptRuntimeException(StringUtil.format("Invalid property or can't write: com.github.stuxuhai.hdata.api.Record#{}", property));
+    }
+}

--- a/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/writer/WitWriter.java
+++ b/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/writer/WitWriter.java
@@ -1,0 +1,100 @@
+package com.github.stuxuhai.hdata.plugin.wit.writer;
+
+import java.io.IOException;
+import com.github.stuxuhai.hdata.api.JobContext;
+import com.github.stuxuhai.hdata.api.PluginConfig;
+import com.github.stuxuhai.hdata.api.Record;
+import com.github.stuxuhai.hdata.api.Writer;
+import com.github.stuxuhai.hdata.core.PluginLoader;
+import com.github.stuxuhai.hdata.exception.HDataException;
+import com.github.stuxuhai.hdata.plugin.wit.WitEnginePlugin;
+import com.github.stuxuhai.hdata.plugin.wit.WitRecord;
+import com.github.stuxuhai.hdata.util.PluginUtils;
+import com.google.common.base.Preconditions;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+import org.febit.wit.Engine;
+import org.febit.wit.Template;
+import org.febit.wit.io.impl.DiscardOut;
+import org.febit.wit.util.KeyValuesUtil;
+
+public class WitWriter extends Writer {
+
+    public static final String KEY_INPUT = "input";
+    public static final String KEY_RESULT = "result";
+
+    protected static final DiscardOut DISCARD_OUT = new DiscardOut();
+
+    private static class LazyHolder {
+
+        static final Engine ENGINE;
+
+        static {
+            ENGINE = Engine.create("hdata-wit-writer.wim");
+            Iterator<WitEnginePlugin> iterator = ServiceLoader.load(WitEnginePlugin.class).iterator();
+            while (iterator.hasNext()) {
+                iterator.next().handle(ENGINE);
+            }
+        }
+    }
+
+    private Template template = null;
+    private Writer innerWriter = null;
+    private final String[] templateParamNames = new String[]{KEY_INPUT, KEY_RESULT};
+
+    protected Template createTemplate(String tmpl) throws IOException {
+        return LazyHolder.ENGINE.getTemplate("code: var input,result; (()->{\n" + tmpl + "\n})();");
+    }
+
+    protected WitRecord executeTemplate(Record input) {
+        WitRecord result = new WitRecord();
+        template.merge(KeyValuesUtil.wrap(templateParamNames, new Object[]{input, result}), DISCARD_OUT);
+        return result;
+    }
+
+    protected Writer createInnerWriter(JobContext context, PluginConfig writerConfig) {
+        String innerWriterName = writerConfig.getString(WitWriterProperties.INNER_WRITER);
+        Preconditions.checkNotNull(innerWriterName, "Wit writer required property: " + WitWriterProperties.INNER_WRITER);
+
+        String writerClassName = PluginLoader.getWriterClassName(innerWriterName);
+        Preconditions.checkNotNull(writerClassName, "Can not find class for writer: " + innerWriterName);
+
+        try {
+            return (Writer) PluginUtils.loadClass(innerWriterName, writerClassName).newInstance();
+        } catch (Exception e) {
+            throw new HDataException("Can not create new writer instance for: " + innerWriterName, e);
+        }
+    }
+
+    @Override
+    public void prepare(JobContext context, PluginConfig writerConfig) {
+        String wit = writerConfig.getString(WitWriterProperties.WIT);
+        Preconditions.checkNotNull(wit, "Wit writer required property: " + WitWriterProperties.WIT);
+
+        try {
+            this.template = createTemplate(wit);
+        } catch (IOException ex) {
+            throw new HDataException("Failed to load wit", ex);
+        }
+        this.template.reload();
+
+        PluginConfig innerWriterConfig = new PluginConfig();
+        innerWriterConfig.putAll(writerConfig);
+        innerWriterConfig.remove(WitWriterProperties.INNER_WRITER);
+        innerWriterConfig.remove(WitWriterProperties.WIT);
+        this.innerWriter = createInnerWriter(context, writerConfig);
+        this.innerWriter.prepare(context, innerWriterConfig);
+    }
+
+    @Override
+    public void execute(Record input) {
+        WitRecord result = executeTemplate(input);
+        this.innerWriter.execute(result);
+    }
+
+    @Override
+    public void close() {
+        this.innerWriter.close();
+    }
+
+}

--- a/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/writer/WitWriterProperties.java
+++ b/hdata-wit/src/main/java/com/github/stuxuhai/hdata/plugin/wit/writer/WitWriterProperties.java
@@ -1,0 +1,6 @@
+package com.github.stuxuhai.hdata.plugin.wit.writer;
+
+public class WitWriterProperties {
+    public static final String WIT = "wit";
+    public static final String INNER_WRITER = "witInnerWriter";
+}

--- a/hdata-wit/src/main/resources/META-INF/services/com.github.stuxuhai.hdata.plugin.wit.WitEnginePlugin
+++ b/hdata-wit/src/main/resources/META-INF/services/com.github.stuxuhai.hdata.plugin.wit.WitEnginePlugin
@@ -1,0 +1,2 @@
+
+com.github.stuxuhai.hdata.plugin.wit.Methods

--- a/hdata-wit/src/main/resources/hdata-wit-writer.wim
+++ b/hdata-wit/src/main/resources/hdata-wit-writer.wim
@@ -1,0 +1,19 @@
+
+[engine]
+
+[logger :slf4jLogger]
+[nativeFactory :defaultNativeFactory]
+[resolverManager :defaultResolverManager]
+
+[codeStringLoader :stringLoader]
+codeFirst=true
+
+[routeLoader]
+loaders +='''
+  code: codeStringLoader
+'''
+
+[resolverManager]
+resolvers+='''
+  com.github.stuxuhai.hdata.plugin.wit.resolvers.RecordResolver
+'''

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
+		<slf4j.version>1.7.12</slf4j.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
 		<hadoop.version>2.7.1</hadoop.version>
 		<hbase.version>1.1.2</hbase.version>
@@ -167,5 +168,6 @@
 		<module>hdata-hbase</module>
 		<module>hdata-mongodb</module>
 		<module>hdata-excel</module>
+		<module>hdata-wit</module>
 	</modules>
 </project>


### PR DESCRIPTION
这是自用的一个插件
**看看需不需要, 不合并也没关系** 
这是使用 febit-wit 模板引擎的脚本功能实现的一个 writer,
可以包裹一个普通的 writer, 并对即将写入的 Record 做 *过滤*,*展开*,*转换*

示例:
```sh
CODE='
// 新建一个 record
var result=newRecord()
// 转换
result[0]=input[0]
result[1]=input[1]+"_suffix"
result[2]=input[2]=="E350"?true:false; result[3]=input[3]+ "_" +input[4]
// 展开: 返回三个, 结果被展开成了三行 (仅供展示, 字段数量没有对齐, 不要效仿)
return [result, input, copyRecord(input)];
//      也可以返回空数组, 即此输入被忽略(过滤)
//  return [];  // 或者 return null, 或者没有返回语句
//      返回单个 record 时可以不用数组
//  return result;
//      返回单个 record 时可以不用数组
//  return result;
//      未实现:  返回字符串表示被过滤原因
//  return "title is required";
'
bin/hdata --reader csv -Rpath=sample.csv --writer wit -Wwit="$CODE" -WwitInnerWriter=console
```

