### PR TITLE
Replace hbase-client by hbase-shaded-client

### DIFF
--- a/hdata-hbase/pom.xml
+++ b/hdata-hbase/pom.xml
@@ -37,7 +37,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
-			<artifactId>hbase-client</artifactId>
+			<artifactId>hbase-shaded-client</artifactId>
 			<version>${hbase.version}</version>
 			<scope>${hbase.scope}</scope>
 		</dependency>


### PR DESCRIPTION
Hbase 1.1.12 uses an early version of guava (<=16), while Guava hides the `Stopwatch` hbase used since 17.0.
References: [Hide deprecated Stopwatch constructors in Guava](https://github.com/google/guava/commit/fd0cbc2c5c90e85fb22c8e86ea19630032090943)

The hbase-client:1.1.12 used in current HData would cause an exception while reading from HBase, I don't know if you are going to update the version of hbase, but one of the lazy solutions is using [hbase-shaded-client](http://mvnrepository.com/artifact/org.apache.hbase/hbase-shaded-client).

Notes: The exception caused by accessing `Stopwatch` from hbase.
```plain
2017-12-13 10:39:35.394 [main] ERROR com.github.stuxuhai.hdata.core.HData - java.util.concurrent.ExecutionException
        at java.util.concurrent.FutureTask.report(FutureTask.java:122)
        at java.util.concurrent.FutureTask.get(FutureTask.java:192)
        at com.github.stuxuhai.hdata.core.HData.start(HData.java:182)
        at com.github.stuxuhai.hdata.CliDriver.main(CliDriver.java:149)
Caused by: null
        at com.github.stuxuhai.hdata.plugin.reader.hbase.HBaseReader.execute(HBaseReader.java:113)
        at com.github.stuxuhai.hdata.core.ReaderWorker.call(ReaderWorker.java:28)
        at com.github.stuxuhai.hdata.core.ReaderWorker.call(ReaderWorker.java:10)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.hadoop.hbase.DoNotRetryIOException: java.lang.IllegalAccessError: tried to access method com.google.common.base.Stopwatch.<init>()V from class org.apache.h$
doop.hbase.zookeeper.MetaTableLocator
        at org.apache.hadoop.hbase.client.RpcRetryingCaller.translateException(RpcRetryingCaller.java:229)
        at org.apache.hadoop.hbase.client.RpcRetryingCaller.callWithoutRetries(RpcRetryingCaller.java:202)
        at org.apache.hadoop.hbase.client.ClientScanner.call(ClientScanner.java:320)
        at org.apache.hadoop.hbase.client.ClientScanner.nextScanner(ClientScanner.java:295)
        at org.apache.hadoop.hbase.client.ClientScanner.initializeScannerInConstruction(ClientScanner.java:160)
        at org.apache.hadoop.hbase.client.ClientScanner.<init>(ClientScanner.java:155)
        at org.apache.hadoop.hbase.client.HTable.getScanner(HTable.java:821)
        at com.github.stuxuhai.hdata.plugin.reader.hbase.HBaseReader.execute(HBaseReader.java:95)
        ... 8 more
Caused by: java.lang.IllegalAccessError: tried to access method com.google.common.base.Stopwatch.<init>()V from class org.apache.hadoop.hbase.zookeeper.MetaTableLocator
        at org.apache.hadoop.hbase.zookeeper.MetaTableLocator.blockUntilAvailable(MetaTableLocator.java:596)
        at org.apache.hadoop.hbase.zookeeper.MetaTableLocator.blockUntilAvailable(MetaTableLocator.java:580)
        at org.apache.hadoop.hbase.zookeeper.MetaTableLocator.blockUntilAvailable(MetaTableLocator.java:559)
        at org.apache.hadoop.hbase.client.ZooKeeperRegistry.getMetaRegionLocation(ZooKeeperRegistry.java:61)
        at org.apache.hadoop.hbase.client.ConnectionManager$HConnectionImplementation.locateMeta(ConnectionManager.java:1185)
        at org.apache.hadoop.hbase.client.ConnectionManager$HConnectionImplementation.locateRegion(ConnectionManager.java:1152)
        at org.apache.hadoop.hbase.client.ConnectionManager$HConnectionImplementation.relocateRegion(ConnectionManager.java:1126)
        at org.apache.hadoop.hbase.client.ConnectionManager$HConnectionImplementation.locateRegionInMeta(ConnectionManager.java:1331)
        at org.apache.hadoop.hbase.client.ConnectionManager$HConnectionImplementation.locateRegion(ConnectionManager.java:1155)
        at org.apache.hadoop.hbase.client.RpcRetryingCallerWithReadReplicas.getRegionLocations(RpcRetryingCallerWithReadReplicas.java:300)
        at org.apache.hadoop.hbase.client.ScannerCallableWithReplicas.call(ScannerCallableWithReplicas.java:151)
        at org.apache.hadoop.hbase.client.ScannerCallableWithReplicas.call(ScannerCallableWithReplicas.java:59)
        at org.apache.hadoop.hbase.client.RpcRetryingCaller.callWithoutRetries(RpcRetryingCaller.java:200)
        ... 14 more
```